### PR TITLE
Missing CSV fixture file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 lib-cov
 *.seed
 *.log
-*.csv
 *.dat
 *.out
 *.pid

--- a/test/fixtures/fixture.csv
+++ b/test/fixtures/fixture.csv
@@ -1,0 +1,1 @@
+some,value

--- a/test/index.js
+++ b/test/index.js
@@ -138,7 +138,7 @@ test('Supported file types list can be completely custom', function (t) {
 });
 
 test('Supported file types list can be completely customized via options', function (t) {
-  t.plan(1);
+  t.plan(2);
 
   var output = {};
 
@@ -153,6 +153,7 @@ test('Supported file types list can be completely customized via options', funct
 
   function finish () {
     t.equal(output.xml, xml);
+    t.equal(output.csv, csv);
   }
 
 });


### PR DESCRIPTION
Tests are not passing anyway :

```
partialify/node_modules/tape/index.js:65
        throw err
              ^
TypeError: Object #<Object> has no method 'match'
    at resolve (partialify/node_modules/browserify/node_modules/module-deps/node_modules/resolve/lib/async.js:29:11)
    at makeTransform (partialify/node_modules/browserify/node_modules/module-deps/index.js:284:9)
    at ap (partialify/node_modules/browserify/node_modules/module-deps/index.js:203:13)
    at applyTransforms (partialify/node_modules/browserify/node_modules/module-deps/index.js:220:11)
    at partialify/node_modules/browserify/node_modules/module-deps/index.js:171:17
    at fs.js:271:14
    at Object.oncomplete (fs.js:107:15)
```

I don't know what's wrong but if you remove `{onlyAllow: ['xml', 'csv']}` https://github.com/LoicMahieu/partialify/blob/master/test/index.js#L147, tests are ok.